### PR TITLE
Resolve missing tips links & fix misc spelling

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -54,6 +54,7 @@ The premise of this tutorial is that you write code yourself, and understand wha
 - [Tips - Client vs Bot](/tips/clientbot)
 - [Tips - Gateway Intents](/tips/intents)
 - [Tips - Storing Data](/tips/storage)
+- [Tips - Cogs vs Main](/tips/cogs)
 
 ---
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -55,6 +55,8 @@ The premise of this tutorial is that you write code yourself, and understand wha
 - [Tips - Gateway Intents](/tips/intents)
 - [Tips - Storing Data](/tips/storage)
 - [Tips - Cogs vs Main](/tips/cogs)
+- [Tips - Gateway Intents](/tips/intents)
+- [Tips - Optional Arguments (Coming Soon)](/tips/optional)
 
 ---
 

--- a/content/tips/_index.md
+++ b/content/tips/_index.md
@@ -13,4 +13,4 @@ description: "A collection of tips for discord.py to help made better, more effi
 - [Tips - Storing Data](/tips/storage)
 - [Tips - Cogs vs Main](/tips/cogs)
 - [Tips - Gateway Intents](/tips/intents)
-- [Tips - Gateway Intents](/tips/optional)
+- [Tips - Optional Arguments (Coming Soon)](/tips/optional)

--- a/content/tips/_index.md
+++ b/content/tips/_index.md
@@ -12,3 +12,5 @@ description: "A collection of tips for discord.py to help made better, more effi
 - [Tips - Gateway Intents](/tips/intents)
 - [Tips - Storing Data](/tips/storage)
 - [Tips - Cogs vs Main](/tips/cogs)
+- [Tips - Gateway Intents](/tips/intents)
+- [Tips - Gateway Intents](/tips/optional)

--- a/content/tips/_index.md
+++ b/content/tips/_index.md
@@ -11,3 +11,4 @@ description: "A collection of tips for discord.py to help made better, more effi
 - [Tips - Client vs Bot](/tips/clientbot)
 - [Tips - Gateway Intents](/tips/intents)
 - [Tips - Storing Data](/tips/storage)
+- [Tips - Cogs vs Main](/tips/cogs)

--- a/content/tips/cogs.md
+++ b/content/tips/cogs.md
@@ -68,7 +68,7 @@ def setup(bot: commands.Bot):
     bot.add_cog(MyCog(bot))
 ```
 
-The first important thing to note here is that wehn creating the class we have a `bot` argment in the cog's constructor. This means that we can have cogs in other files without needing to somehow import and reference the bot from the main file.
+The first important thing to note here is that when creating the class we have a `bot` argment in the cog's constructor. This means that we can have cogs in other files without needing to somehow import and reference the bot from the main file.
 
 Next, there's the `setup` function. This is what discord.py looks out for when trying to load the cog. It **must** be called `setup` else the cog will fail to load and you'll get an error.
 


### PR DESCRIPTION
This pr resolves a few missing links for the `tips` section as well as addressing some spelling